### PR TITLE
Only install on 2.7 and 2.8

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -33,11 +33,26 @@ function xmldb_atto_imagedragdrop_install() {
     global $CFG;
 
     $toolbar = get_config('editor_atto', 'toolbar');
+    $pos = stristr($toolbar, 'imagedragdrop');
 
-    if (!stristr($toolbar, 'imagedragdrop')) {
-        // Add imagedragdrop after image plugin.
-        $toolbar = preg_replace('/(.+?=.+?)image($|\s|,)/m', '$1image, imagedragdrop$2', $toolbar, 1);
-        set_config('toolbar', $toolbar, 'editor_atto');
+    // Check the Moodle version; we shouldn't install if we're not on 2.7 or 2.8.
+    $prefix = intval(substr($CFG->version, 0, 8));
+    if($prefix >= 20140527 && $prefix <= 20141110) {
+
+        // Install as normal.
+        if (!$pos) {
+            // Add imagedragdrop after image plugin.
+            $toolbar = preg_replace('/(.+?=.+?)image($|\s|,)/m', '$1image, imagedragdrop$2', $toolbar, 1);
+        }
+
+    } else {
+
+        // Not on 2.7 or 2.8 - remove usage from toolbar config if it's present.
+        if ($pos) {
+            $toolbar = preg_replace('/(.+?=.+?)imagedragdrop($|\s|,)/m', '$1', $toolbar, 1);
+            set_config('toolbar', $toolbar, 'editor_atto');
+        }
+
     }
 
     return true;


### PR DESCRIPTION
Now that drag and drop functionality is up for integration with 2.9, we should make sure that the plugin doesn't install on Moodle versions earlier than 2.7.x and after 2.8.x (and to remove usage otherwise).